### PR TITLE
Implement Sync Info events on sending and receiving

### DIFF
--- a/ts/fast-sync/channels.ts
+++ b/ts/fast-sync/channels.ts
@@ -9,9 +9,10 @@ type WebRTCSyncPackage =
     { type: 'finish' }
 
 export class WebRTCFastSyncReceiverChannel implements FastSyncReceiverChannel {
-    private syncInfoPromise: ResolvablePromise<FastSyncInfo>;
+
+    private syncInfoPromise: ResolvablePromise<FastSyncInfo> = resolvablePromise<FastSyncInfo>();
+
     constructor(private options : { peer : SimplePeer.Instance }) {
-        this.syncInfoPromise = resolvablePromise<FastSyncInfo>()
     }
 
     async* streamObjectBatches() : AsyncIterableIterator<{collection : string, objects : any[]}> {

--- a/ts/fast-sync/channels.ts
+++ b/ts/fast-sync/channels.ts
@@ -1,15 +1,17 @@
 import * as SimplePeer from 'simple-peer'
-import { FastSyncBatch, FastSyncSenderChannel, FastSyncReceiverChannel } from "./types";
-import { resolvablePromise } from './utils';
+import {FastSyncBatch, FastSyncSenderChannel, FastSyncReceiverChannel, FastSyncInfo} from "./types";
+import {ResolvablePromise, resolvablePromise} from './utils';
 
 type WebRTCSyncPackage =
     { type: 'batch', batch : any } |
     { type: 'confirm' } |
-    { type: 'sync-info' } |
+    { type: 'sync-info', info: FastSyncInfo } |
     { type: 'finish' }
 
 export class WebRTCFastSyncReceiverChannel implements FastSyncReceiverChannel {
+    private syncInfoPromise: ResolvablePromise<FastSyncInfo>;
     constructor(private options : { peer : SimplePeer.Instance }) {
+        this.syncInfoPromise = resolvablePromise<FastSyncInfo>()
     }
 
     async* streamObjectBatches() : AsyncIterableIterator<{collection : string, objects : any[]}> {
@@ -29,6 +31,11 @@ export class WebRTCFastSyncReceiverChannel implements FastSyncReceiverChannel {
                     break
                 }
 
+                if (syncPackage.type === 'sync-info') {
+                    this.syncInfoPromise.resolve(syncPackage.info)
+                    break;
+                }
+
                 if (syncPackage.type === 'batch') {
                     yield syncPackage.batch
                     this.options.peer.send(JSON.stringify({ type: 'confirmation' }))
@@ -38,13 +45,19 @@ export class WebRTCFastSyncReceiverChannel implements FastSyncReceiverChannel {
             this.options.peer.removeListener('data', dataHandler)
         }
     }
+
+    async receiveSyncInfo() {
+        return await this.syncInfoPromise.promise
+    }
 }
 
 export class WebRTCFastSyncSenderChannel implements FastSyncSenderChannel {
     constructor(private options : { peer : SimplePeer.Instance }) {
     }
 
-    async sendSyncInfo() {
+    async sendSyncInfo(info: FastSyncInfo) {
+        const syncPackage : WebRTCSyncPackage = { type: 'sync-info', info} ;
+        this.options.peer.send(JSON.stringify(syncPackage))
     }
 
     async sendObjectBatch (batch : FastSyncBatch) {
@@ -76,12 +89,17 @@ export function createMemoryChannel() {
     // resolves when data has been received, and replaced right after
     let recvBatchPromise = resolvablePromise<void>()
 
+    let sendSyncInfoPromise = resolvablePromise<FastSyncInfo>()
+    let recvSyncInfoPromise = resolvablePromise<void>()
+
     const senderChannel : FastSyncSenderChannel = {
-        sendSyncInfo: async () => {
+        sendSyncInfo: async (syncInfo: FastSyncInfo) => {
             // transmitPromise = resolvablePromise()
             // sendPromise.resolve()
             // await transmitPromise.promise
             // sendPromise = resolvablePromise<void>()
+            sendSyncInfoPromise.resolve(syncInfo)
+            await recvSyncInfoPromise.promise
         },
         sendObjectBatch: async (batch : FastSyncBatch) => {
             sendBatchPromise.resolve(batch)
@@ -101,13 +119,20 @@ export function createMemoryChannel() {
                 if (!batch) {
                     break
                 }
-                sendBatchPromise = resolvablePromise<FastSyncBatch | null>()
+                sendBatchPromise = resolvablePromise<FastSyncBatch>()
                 yield batch
                 recvBatchPromise.resolve()
                 recvBatchPromise = resolvablePromise<void>()
                 // console.log('stream: end iter')
             }
             // console.log('stream: end')
+        },
+        receiveSyncInfo: async function() {
+            const info = await sendSyncInfoPromise.promise
+            sendSyncInfoPromise = resolvablePromise<FastSyncInfo>()
+            recvSyncInfoPromise.resolve()
+            recvSyncInfoPromise = resolvablePromise<void>()
+            return info;
         }
     }
 

--- a/ts/fast-sync/index.test.ts
+++ b/ts/fast-sync/index.test.ts
@@ -123,6 +123,15 @@ describe('Fast initial sync', () => {
             }]]
         ])
 
+        expect(receiverEventSpy.popEvents()).toEqual([
+            ['prepared', [{
+                syncInfo: {
+                    collectionCount: 1,
+                    objectCount: 2,
+                }
+            }]]
+        ])
+
         expect(await device2.storageManager.collection('test').findObjects({})).toEqual([
             { key: 'one', label: 'Foo' },
             { key: 'two', label: 'Bar' },

--- a/ts/fast-sync/index.test.ts
+++ b/ts/fast-sync/index.test.ts
@@ -123,17 +123,20 @@ describe('Fast initial sync', () => {
             }]],
             ['progress', [{
                 progress: {
-                    objectsProcessed: 0,
+                    lastObjectsProcessed: 0,
+                    totalObjectsProcessed: 0,
                 }
             }]],
             ['progress', [{
                 progress: {
-                    objectsProcessed: 1,
+                    lastObjectsProcessed: 1,
+                    totalObjectsProcessed: 1,
                 }
             }]],
             ['progress', [{
                 progress: {
-                    objectsProcessed: 1,
+                    lastObjectsProcessed: 1,
+                    totalObjectsProcessed: 2,
                 }
             }]]
         ]

--- a/ts/fast-sync/index.test.ts
+++ b/ts/fast-sync/index.test.ts
@@ -114,28 +114,31 @@ describe('Fast initial sync', () => {
         await receiverPromise
         await senderPromise
 
+        const expectedSyncInfo = {
+            collectionCount: 1,
+            objectCount: 2,
+        }
         const allExpectedEvents = [
             ['prepared', [{
                 syncInfo: {
-                    collectionCount: 1,
-                    objectCount: 2,
+                    ...expectedSyncInfo
                 }
             }]],
             ['progress', [{
                 progress: {
-                    lastObjectsProcessed: 0,
+                    ...expectedSyncInfo,
                     totalObjectsProcessed: 0,
                 }
             }]],
             ['progress', [{
                 progress: {
-                    lastObjectsProcessed: 1,
+                    ...expectedSyncInfo,
                     totalObjectsProcessed: 1,
                 }
             }]],
             ['progress', [{
                 progress: {
-                    lastObjectsProcessed: 1,
+                    ...expectedSyncInfo,
                     totalObjectsProcessed: 2,
                 }
             }]]

--- a/ts/fast-sync/index.test.ts
+++ b/ts/fast-sync/index.test.ts
@@ -102,8 +102,8 @@ describe('Fast initial sync', () => {
         const senderEventSpy = testSetup.createEventSpy()
         const receiverEventSpy = testSetup.createEventSpy()
 
-        senderEventSpy.listen(senderFastSync.events as EventEmitter, ['prepared'])
-        receiverEventSpy.listen(senderFastSync.events as EventEmitter, ['prepared'])
+        senderEventSpy.listen(senderFastSync.events as EventEmitter, ['prepared', 'progress'])
+        receiverEventSpy.listen(senderFastSync.events as EventEmitter, ['prepared', 'progress'])
 
         const senderPromise = senderFastSync.execute()
         const receiverPromise = receiverFastSync.execute()
@@ -114,23 +114,31 @@ describe('Fast initial sync', () => {
         await receiverPromise
         await senderPromise
 
-        expect(senderEventSpy.popEvents()).toEqual([
+        const allExpectedEvents = [
             ['prepared', [{
                 syncInfo: {
                     collectionCount: 1,
                     objectCount: 2,
                 }
-            }]]
-        ])
-
-        expect(receiverEventSpy.popEvents()).toEqual([
-            ['prepared', [{
-                syncInfo: {
-                    collectionCount: 1,
-                    objectCount: 2,
+            }]],
+            ['progress', [{
+                progress: {
+                    objectsProcessed: 0,
+                }
+            }]],
+            ['progress', [{
+                progress: {
+                    objectsProcessed: 1,
+                }
+            }]],
+            ['progress', [{
+                progress: {
+                    objectsProcessed: 1,
                 }
             }]]
-        ])
+        ]
+        expect(senderEventSpy.popEvents()).toEqual(allExpectedEvents)
+        expect(receiverEventSpy.popEvents()).toEqual(allExpectedEvents)
 
         expect(await device2.storageManager.collection('test').findObjects({})).toEqual([
             { key: 'one', label: 'Foo' },

--- a/ts/fast-sync/index.ts
+++ b/ts/fast-sync/index.ts
@@ -44,6 +44,10 @@ export class FastSyncReceiver {
     }
 
     async execute() {
+
+        const syncInfo = await this.options.channel.receiveSyncInfo();
+        this.events.emit('prepared',{syncInfo})
+
         // console.log('recv: entering loop')
         for await (const objectBatch of this.options.channel.streamObjectBatches()) {
             // console.log('recv: start iter')

--- a/ts/fast-sync/types.ts
+++ b/ts/fast-sync/types.ts
@@ -12,7 +12,8 @@ export interface FastSyncInfo {
     collectionCount : number
 }
 export interface FastSyncProgress {
-    objectsProcessed: number
+    totalObjectsProcessed: number
+    lastObjectsProcessed: number
 }
 export interface FastSyncBatch {
     collection : string

--- a/ts/fast-sync/types.ts
+++ b/ts/fast-sync/types.ts
@@ -11,6 +11,9 @@ export interface FastSyncInfo {
     objectCount : number
     collectionCount : number
 }
+export interface FastSyncProgress {
+    objectsProcessed: number
+}
 export interface FastSyncBatch {
     collection : string
     objects : any[]

--- a/ts/fast-sync/types.ts
+++ b/ts/fast-sync/types.ts
@@ -11,9 +11,8 @@ export interface FastSyncInfo {
     objectCount : number
     collectionCount : number
 }
-export interface FastSyncProgress {
+export interface FastSyncProgress extends FastSyncInfo {
     totalObjectsProcessed: number
-    lastObjectsProcessed: number
 }
 export interface FastSyncBatch {
     collection : string

--- a/ts/fast-sync/types.ts
+++ b/ts/fast-sync/types.ts
@@ -5,6 +5,7 @@ export interface FastSyncSenderChannel {
 }
 export interface FastSyncReceiverChannel {
     streamObjectBatches : () => AsyncIterableIterator<FastSyncBatch>
+    receiveSyncInfo: () => Promise<FastSyncInfo>
 }
 export interface FastSyncInfo {
     objectCount : number


### PR DESCRIPTION
This PR implements:

- Sending & Receiving an initial `FastSyncInfo` object containing the total objects to process
- Emitting `FastSyncProgress` objects per batch processing, describing the number of objects sent ( in the case of sending) and received and written (in the case of receiving).

Tests included. 

I'm still new to the Sync code so feedback welcome.