### PR TITLE
Sync using faster storex create op - rawCreateObjects

### DIFF
--- a/ts/fast-sync/index.ts
+++ b/ts/fast-sync/index.ts
@@ -88,17 +88,13 @@ export class FastSyncReceiver {
         })
         for await (const objectBatch of this.options.channel.streamObjectBatches()) {
             // console.log('recv: start iter')
-            for (const object of objectBatch.objects) {
-                await this.options.storageManager
-                    .collection(objectBatch.collection)
-                    .createObject(object)
-            }
+            await this.options.storageManager.collection(objectBatch.collection).rawCreateObjects(objectBatch.objects, {withNestedObjects: false})
             this.totalObjectsProcessed += objectBatch.objects.length
             this.events.emit('progress', {
                 progress: {
                     ...syncInfo,
                     totalObjectsProcessed: this.totalObjectsProcessed,
-                },
+                }
             })
             // console.log('recv: end iter')
         }

--- a/ts/logging-middleware/index.test.ts
+++ b/ts/logging-middleware/index.test.ts
@@ -61,6 +61,16 @@ describe('Sync logging middleware', () => {
         ])
     })
 
+    it('should not write rawCreateObjects operations to the ClientSyncLog', async () => {
+        const { storageManager, clientSyncLog } = await setupTest({now: () => 3})
+        await storageManager.collection('user').rawCreateObjects([
+            {id: 53, displayName: 'John Doe'},
+            {id: 54, displayName: 'Jane Doe'},
+        ],{withNestedObjects: false})
+        expect(await clientSyncLog.getEntriesCreatedAfter(1)).toEqual([
+        ])
+    })
+
     it('should write updateObject operations done by pk on a single field to the ClientSyncLog in a batch write', async () => {
         let now = 2
         const { storageManager, clientSyncLog } = await setupTest({


### PR DESCRIPTION
Use the storex operation `rawCreateObjects` to sync rather than iterate through each sync batch using `createObject`.