### PR TITLE
Post-receive processing

### DIFF
--- a/ts/index.test.ts
+++ b/ts/index.test.ts
@@ -724,9 +724,10 @@ function integrationTests(withTestDependencies: TestDependencyInjector) {
                     )
                 }
 
+                await sync({ clientName: 'one' })
                 await sync({
-                    clientName: 'one',
-                    postReceive: async (params: { entry: SharedSyncLogEntry<'deserialized-data'> }) => {
+                    clientName: 'two',
+                    postReceive: async params => {
                         if (params.entry.data.operation !== 'create') {
                             return params
                         }
@@ -739,7 +740,6 @@ function integrationTests(withTestDependencies: TestDependencyInjector) {
                         }
                     },
                 })
-                await sync({ clientName: 'two' })
 
                 expect(
                     await clients.two.storageManager
@@ -748,7 +748,7 @@ function integrationTests(withTestDependencies: TestDependencyInjector) {
                 ).toEqual([users[0], users[2]])
             },
             { includeTimestampChecks: true },
-            )
+        )
 
         it(
             'should allow for modifying received operations',
@@ -765,9 +765,10 @@ function integrationTests(withTestDependencies: TestDependencyInjector) {
                     )
                 }
 
+                await sync({ clientName: 'one' })
                 await sync({
-                    clientName: 'one',
-                    postReceive: async (params: { entry: SharedSyncLogEntry<'deserialized-data'>}) => {
+                    clientName: 'two',
+                    postReceive: async params => {
                         if (params.entry.data.operation !== 'create') {
                             return params
                         }
@@ -775,16 +776,19 @@ function integrationTests(withTestDependencies: TestDependencyInjector) {
                         return {
                             entry: {
                                 ...params.entry,
-                                value: {
-                                    ...params.entry.data.value,
-                                    displayName:
-                                        params.entry.data.value.displayName + '!!',
+                                data: {
+                                    ...params.entry.data,
+                                    value: {
+                                        ...params.entry.data.value,
+                                        displayName:
+                                            params.entry.data.value
+                                                .displayName + '!!',
+                                    },
                                 },
                             },
                         }
                     },
                 })
-                await sync({ clientName: 'two' })
 
                 expect(
                     await clients.two.storageManager

--- a/ts/index.test.ts
+++ b/ts/index.test.ts
@@ -710,6 +710,96 @@ function integrationTests(withTestDependencies: TestDependencyInjector) {
         )
 
         it(
+            'should allow for filtering received operations',
+            async (dependencies: TestDependencies) => {
+                const { clients, sync } = await setupSyncTest(dependencies)
+                const users = []
+                for (const displayName of ['Jane', 'Joe', 'Jack']) {
+                    users.push(
+                        (await clients.one.storageManager
+                            .collection('user')
+                            .createObject({
+                                displayName,
+                            })).object,
+                    )
+                }
+
+                await sync({
+                    clientName: 'one',
+                    postReceive: async (params: { entry: SharedSyncLogEntry<'deserialized-data'> }) => {
+                        if (params.entry.data.operation !== 'create') {
+                            return params
+                        }
+
+                        return {
+                            entry:
+                                params.entry.data.value.displayName !== 'Joe'
+                                    ? params.entry
+                                    : null,
+                        }
+                    },
+                })
+                await sync({ clientName: 'two' })
+
+                expect(
+                    await clients.two.storageManager
+                        .collection('user')
+                        .findObjects({}),
+                ).toEqual([users[0], users[2]])
+            },
+            { includeTimestampChecks: true },
+            )
+
+        it(
+            'should allow for modifying received operations',
+            async (dependencies: TestDependencies) => {
+                const { clients, sync } = await setupSyncTest(dependencies)
+                const users = []
+                for (const displayName of ['Jane', 'Joe', 'Jack']) {
+                    users.push(
+                        (await clients.one.storageManager
+                            .collection('user')
+                            .createObject({
+                                displayName,
+                            })).object,
+                    )
+                }
+
+                await sync({
+                    clientName: 'one',
+                    postReceive: async (params: { entry: SharedSyncLogEntry<'deserialized-data'>}) => {
+                        if (params.entry.data.operation !== 'create') {
+                            return params
+                        }
+
+                        return {
+                            entry: {
+                                ...params.entry,
+                                value: {
+                                    ...params.entry.data.value,
+                                    displayName:
+                                        params.entry.data.value.displayName + '!!',
+                                },
+                            },
+                        }
+                    },
+                })
+                await sync({ clientName: 'two' })
+
+                expect(
+                    await clients.two.storageManager
+                        .collection('user')
+                        .findObjects({}),
+                ).toEqual([
+                    { ...users[0], displayName: 'Jane!!' },
+                    { ...users[1], displayName: 'Joe!!' },
+                    { ...users[2], displayName: 'Jack!!' },
+                ])
+            },
+            { includeTimestampChecks: true },
+        )
+
+        it(
             'should correctly sync createObject and updateObject operations',
             async (dependencies: TestDependencies) => {
                 const { clients, sync } = await setupSyncTest(dependencies)

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -55,17 +55,19 @@ export type SyncPreSendProcessor = (params: {
 export type SyncPostReceiveProcessor = (params: {
     entry: ClientSyncLogEntry
 }) => Promise<{ entry: ClientSyncLogEntry | null }>
-
-export async function shareLogEntries(args: {
+export interface SyncOptions {
     clientSyncLog: ClientSyncLogStorage
     sharedSyncLog: SharedSyncLog
+    now: number | '$now'
     userId: number | string
     deviceId: number | string
-    now: number | '$now'
     serializer?: SyncSerializer
     preSend?: SyncPreSendProcessor
+    postReceive?: SyncPostReceiveProcessor
     syncEvents?: SyncEvents
-}) {
+}
+
+export async function shareLogEntries(args: SyncOptions) {
     const preSend: SyncPreSendProcessor = args.preSend || (async args => args)
     const serializeEntryData = args.serializer
         ? args.serializer.serializeSharedSyncLogEntryData
@@ -108,15 +110,9 @@ export async function shareLogEntries(args: {
     })
 }
 
-export async function receiveLogEntries(args: {
-    clientSyncLog: ClientSyncLogStorage
-    sharedSyncLog: SharedSyncLog
-    userId: number | string
-    deviceId: number | string
-    now: number | '$now'
-    serializer?: SyncSerializer
-    syncEvents?: SyncEvents
-}) {
+export async function receiveLogEntries(args: SyncOptions) {
+    const postReceive: SyncPostReceiveProcessor =
+        args.postReceive || (async args => args)
     const deserializeEntryData = args.serializer
         ? args.serializer.deserializeSharedSyncLogEntryData
         : async (serialized: string) => JSON.parse(serialized, jsonDateParser)
@@ -125,23 +121,30 @@ export async function receiveLogEntries(args: {
         userId: args.userId,
         deviceId: args.deviceId,
     })
+
+    const processedEntries = (await Promise.all(
+        logUpdate.entries.map(async entry => {
+            const deserializedEntry: SharedSyncLogEntry<'deserialized-data'> = {
+                ...entry,
+                data: await deserializeEntryData(entry.data),
+            }
+
+            const postProcessed = await postReceive({
+                entry: deserializedEntry,
+            })
+            return postProcessed.entry
+        }),
+    )).filter(entry => !!entry) as SharedSyncLogEntry<'deserialized-data'>[]
+
     if (args.syncEvents) {
         args.syncEvents.emit('receivedSharedEntries', {
             entries: logUpdate.entries,
             deviceId: args.deviceId,
         })
     }
-    await args.clientSyncLog.insertReceivedEntries(
-        await Promise.all(
-            logUpdate.entries.map(async entry => {
-                return {
-                    ...entry,
-                    data: await deserializeEntryData(entry.data),
-                }
-            }),
-        ),
-        { now: args.now },
-    )
+    await args.clientSyncLog.insertReceivedEntries(processedEntries, {
+        now: args.now,
+    })
     await args.sharedSyncLog.markAsSeen(logUpdate, {
         userId: args.userId,
         deviceId: args.deviceId,
@@ -161,19 +164,12 @@ export async function writeReconcilation(args: {
     )
 }
 
-export async function doSync(options: {
-    clientSyncLog: ClientSyncLogStorage
-    sharedSyncLog: SharedSyncLog
-    storageManager: StorageManager
-    reconciler: ReconcilerFunction
-    now: number | '$now'
-    userId: number | string
-    deviceId: number | string
-    serializer?: SyncSerializer
-    preSend?: SyncPreSendProcessor
-    postReceive?: SyncPostReceiveProcessor
-    syncEvents?: SyncEvents
-}) {
+export async function doSync(
+    options: SyncOptions & {
+        storageManager: StorageManager
+        reconciler: ReconcilerFunction
+    },
+) {
     await receiveLogEntries(options)
     await shareLogEntries(options)
 

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -24,20 +24,24 @@ export interface SyncSerializer {
 export type SyncEvents = TypedEmitter<SyncEventMap>
 export interface SyncEventMap {
     unsharedClientEntries: (event: {
-        entries: ClientSyncLogEntry[], deviceId: number | string
+        entries: ClientSyncLogEntry[]
+        deviceId: number | string
     }) => void
     sendingSharedEntries: (event: {
-        entries: Omit<SharedSyncLogEntry, 'userId' | 'deviceId' | 'sharedOn'>[],
+        entries: Omit<SharedSyncLogEntry, 'userId' | 'deviceId' | 'sharedOn'>[]
         deviceId: number | string
     }) => void
     receivedSharedEntries: (event: {
-        entries: SharedSyncLogEntry[], deviceId: number | string
+        entries: SharedSyncLogEntry[]
+        deviceId: number | string
     }) => void
     reconcilingEntries: (event: {
-        entries: ClientSyncLogEntry[], deviceId: number | string
+        entries: ClientSyncLogEntry[]
+        deviceId: number | string
     }) => void
     reconciledEntries: (event: {
-        entries: ClientSyncLogEntry[], deviceId: number | string
+        entries: ClientSyncLogEntry[]
+        deviceId: number | string
         reconciliation: any[]
     }) => void
 }
@@ -53,8 +57,9 @@ export type SyncPreSendProcessor = (params: {
     entry: ClientSyncLogEntry
 }) => Promise<{ entry: ClientSyncLogEntry | null }>
 export type SyncPostReceiveProcessor = (params: {
-    entry: ClientSyncLogEntry
-}) => Promise<{ entry: ClientSyncLogEntry | null }>
+    entry: SharedSyncLogEntry<'deserialized-data'>
+}) => Promise<{ entry: SharedSyncLogEntry<'deserialized-data'> | null }>
+
 export interface SyncOptions {
     clientSyncLog: ClientSyncLogStorage
     sharedSyncLog: SharedSyncLog
@@ -75,7 +80,10 @@ export async function shareLogEntries(args: SyncOptions) {
 
     const entries = await args.clientSyncLog.getUnsharedEntries()
     if (args.syncEvents) {
-        args.syncEvents.emit('unsharedClientEntries', { entries, deviceId: args.deviceId })
+        args.syncEvents.emit('unsharedClientEntries', {
+            entries,
+            deviceId: args.deviceId,
+        })
     }
 
     const processedEntries = (await Promise.all(

--- a/ts/integration/continuous-sync.ts
+++ b/ts/integration/continuous-sync.ts
@@ -2,7 +2,13 @@ import { EventEmitter } from 'events'
 import StorageManager from '@worldbrain/storex'
 import { SharedSyncLog } from '../shared-sync-log'
 import { reconcileSyncLog } from '../reconciliation'
-import { doSync, SyncPreSendProcessor, SyncSerializer, SyncEvents } from '../'
+import {
+    doSync,
+    SyncPreSendProcessor,
+    SyncSerializer,
+    SyncEvents,
+    SyncPostReceiveProcessor,
+} from '../'
 import { ClientSyncLogStorage } from '../client-sync-log'
 import { RecurringTask } from '../utils/recurring-task'
 import { SyncSettingsStore } from './settings'
@@ -147,11 +153,14 @@ export class ContinuousSync {
             deviceId: this.deviceId,
             serializer: this.getSerializer() || undefined,
             preSend: this.getPreSendProcessor() || undefined,
+            postReceive: this.getPostReceiveProcessor() || undefined,
             syncEvents,
         })
     }
 
     getPreSendProcessor(): SyncPreSendProcessor | void {}
+
+    getPostReceiveProcessor(): SyncPostReceiveProcessor | void {}
 
     getSerializer(): SyncSerializer | void {}
 }


### PR DESCRIPTION
### Code discussion points:

I have some uncertainties with parts of the code, mainly in the `receiveLogEntries` function. Could you elaborate on these:

1. `receiveLogEntries` seems to take entries from the shared sync log and put them on the client sync log. Hence it seems more appropriate that `SyncPostReceiveProcessor` should be taking in a `SharedSyncLogEntry` rather than a `ClientSyncLogEntry`. Does this sound right, or am I misunderstanding completely and we should be able to get a `ClientSyncLogEntry` from somewhere for post-receive processing?
2. There's a `receivedSharedEntries` event being emitted if `args.syncEvents` is checked. What are the sync events, and where are they listened on? Mainly concerned with this as this event takes the serialized entries as an arg, so not sure if that should be the post-processed entries or not (processing will need deserialization first, so if so we'd need to serialize them back before sending them off with this event emission).
3. `markAsSeen` is called on the shared sync log instance at the end. It gets the `logUpdate` passed in. In the current implementation it doesn't do much with the `logUpdate.entries`, but there is some commented out code that maps over them. Should that `logUpdate.entries` be updated with the post-processed entries, so they are known when being marked as read, or it doesn't matter?

### Current state of `develop` branch:

I have no way currently to test these changes. Tests are currently not working in the storex-workspace repo, or at least I cannot get them to work. It will work on the commit of storex-sync that is currently pointed at from storex-workspace, but updating to the latest `develop` commit (which these changes fork from) results in errors when running `yarn bootstrap` from the storex-workspace root.
There's a whole number of them, mostly looking to do with module resolutions and some typing issues, that I presume came in from your recent changes. Can you verify this?
