### PR TITLE
Initial Sync - Add channel timeout, renames and listeners

### DIFF
--- a/ts/fast-sync/index.test.ts
+++ b/ts/fast-sync/index.test.ts
@@ -556,7 +556,7 @@ describe('Fast initial sync', () => {
 
         it('must detect on the receiver side the connection has stalled', async options => {
             const setup = await setupMinimalTest(options)
-            setup.channels.receiverChannel.timeoutInMiliseconds = 100
+            setup.channels.receiverChannel.packageTimeoutInMiliseconds = 100
             setup.channels.senderChannel.preSend = async () => {
                 return new Promise(resolve => setTimeout(resolve, 500))
             }
@@ -577,7 +577,7 @@ describe('Fast initial sync', () => {
 
         it('must detect on the sender side the connection has stalled', async options => {
             const setup = await setupMinimalTest(options)
-            setup.channels.senderChannel.timeoutInMiliseconds = 100
+            setup.channels.senderChannel.packageTimeoutInMiliseconds = 100
             setup.channels.receiverChannel.postReceive = async () => {
                 return new Promise(resolve => setTimeout(resolve, 400))
             }

--- a/ts/fast-sync/types.ts
+++ b/ts/fast-sync/types.ts
@@ -12,12 +12,14 @@ export type FastSyncPackage<UserPackageType = any> =
     | { type: 'finish' }
     | { type: 'user-package'; package: UserPackageType }
 export interface FastSyncChannelEvents {
-    stalled: () => void
+    packageStalled: () => void
+    channelTimeout: () => void
     paused: () => void
     resumed: () => void
 }
 export interface FastSyncChannel<UserPackageType = any> {
-    timeoutInMiliseconds: number
+    packageTimeoutInMilliseconds: number
+    channelTimeoutInMilliseconds: number
     preSend?: (syncPackage: FastSyncPackage) => Promise<void>
     postReceive?: (syncPackage: FastSyncPackage) => Promise<void>
 

--- a/ts/integration/initial-sync.ts
+++ b/ts/integration/initial-sync.ts
@@ -38,6 +38,7 @@ export type InitialSyncEvents = FastSyncEvents &
         connected: {}
         preSyncSuccess: {}
         finished: {}
+        setupContinuingWithoutICE: {}
     }
 
 export interface InitialSyncDependencies {
@@ -225,7 +226,7 @@ export class InitialSync {
                 this.dependencies.storageManager,
                 { collections: this.dependencies.syncedCollections },
             )
-            const syncOrder = await this.negiotiateSyncOrder({
+            const syncOrder = await this.negotiateSyncOrder({
                 role: options.role,
                 channel: fastSyncChannel.channel,
                 fastSyncInfo,
@@ -251,7 +252,7 @@ export class InitialSync {
         return buildInfo()
     }
 
-    async negiotiateSyncOrder(params: {
+    async negotiateSyncOrder(params: {
         role: FastSyncRole
         channel: FastSyncChannel
         fastSyncInfo: FastSyncInfo
@@ -292,12 +293,13 @@ export class InitialSync {
     async preSync(options: InitialSyncInfo) { }
 
     async getPeer(options: { initiator: boolean }): Promise<Peer.Instance> {
-        let iceServers = undefined
+        let iceServers
         try {
             iceServers = await this.dependencies.getIceServers?.()
         } catch (e) {
-            console.warn('An error occured while trying to get ICE servers, ignoring...')
+            console.warn('An error occurred while trying to get ICE servers, ignoring...')
             console.warn(e)
+            this.events.emit('setupContinuingWithoutICE', {e})
         }
         return new Peer({
             initiator: options.initiator,


### PR DESCRIPTION
This PR adds an overall timeout that is emitted when the channel has been unresponsive for 60s, and disambiguates this from the packageStalled timeout. 